### PR TITLE
Fix update_pull_request doc

### DIFF
--- a/lib/octokit/client/pull_requests.rb
+++ b/lib/octokit/client/pull_requests.rb
@@ -78,14 +78,14 @@ module Octokit
       end
 
       # Update a pull request
-      # @overload update_pull_request(repo, id, title=nil, body=nil, state=nil, options = {})
+      # @overload update_pull_request(repo, number, title=nil, body=nil, state=nil, options = {})
       #   @deprecated
       #   @param repo [Integer, String, Hash, Repository] A GitHub repository.
       #   @param number [Integer] Number of pull request to update.
       #   @param title [String] Title for the pull request.
       #   @param body [String] Body content for pull request. Supports GFM.
       #   @param state [String] State of the pull request. `open` or `closed`.
-      # @overload update_pull_request(repo, id,  options = {})
+      # @overload update_pull_request(repo, number,  options = {})
       #   @param repo [Integer, String, Hash, Repository] A GitHub repository.
       #   @param number [Integer] Number of pull request to update.
       #   @option options [String] :title Title for the pull request.


### PR DESCRIPTION
The example method signature incorrectly uses 'id' instead of 'number', the name of the detailed parameter given. The PR number and not it's ID is the actual thing used, so that was confusing to read at first.